### PR TITLE
asciify to avoid mojibake from HTTP::Tiny

### DIFF
--- a/lib/Slack/Notify.pm
+++ b/lib/Slack/Notify.pm
@@ -9,19 +9,21 @@ use Types::Standard qw(Str);
 use Type::Utils qw(class_type);
 
 use HTTP::Tiny;
-use JSON::MaybeXS;
+use JSON::MaybeXS ();
 
 has hook_url => ( is => 'ro', isa => Str, required => 1 );
 
 has _http => ( is => 'lazy', isa => class_type('HTTP::Tiny') );
 sub _build__http { HTTP::Tiny->new }
 
+my $JSON = JSON::XS->new->ascii;
+
 sub post {
   my ($self, %args) = @_;
   my $payload = Slack::Notify::Payload->new(%args);
   $self->_http->post_form(
     $self->hook_url,
-    { payload => encode_json($payload->to_hash) },
+    { payload => $JSON->encode($payload->to_hash) },
   );
 }
 


### PR DESCRIPTION
HTTP::Tiny assumes that values given to post_form are character strings, and will UTF-8 encode them.  Meanwhile, the old encode_json code was already encoding them.  Let's just build our JSON with ASCII instead of 8-bit characters, then everything should be fine!