### PR TITLE
add IO::Socket::SSL to PREREQ_PM

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ my %WriteMakefileArgs = (
   "PREREQ_PM" => {
     "Getopt::Long::Descriptive" => 0,
     "HTTP::Tiny" => 0,
+    "IO::Socket::SSL" => 0,
     "JSON::MaybeXS" => 0,
     "Moo" => 0,
     "Type::Utils" => 0,


### PR DESCRIPTION
Hi,
thank you for neat library!

Slack webhook url must be https,
so Slack::Notify won't work with https-poor perl environment.
I've met this case, built from vanilla plenv.

I think it's better add IO::Socket::SSL to dependency.
Thanks in advance!